### PR TITLE
Treat `Port` account type as an alias for an investment account

### DIFF
--- a/src/Nerdbank.Qif/Account.cs
+++ b/src/Nerdbank.Qif/Account.cs
@@ -6,11 +6,12 @@ namespace Nerdbank.Qif;
 /// <summary>
 /// The base type for an account.
 /// </summary>
+/// <param name="Type">The type of the account.</param>
 /// <param name="Name">The name of the account.</param>
 /// <remarks>
 /// Supported derived types are <see cref="BankAccount"/> and <see cref="InvestmentAccount"/>.
 /// </remarks>
-public abstract record Account(string Name)
+public abstract record Account(string Type, string Name)
 {
     /// <summary>
     /// Gets the description.
@@ -31,11 +32,6 @@ public abstract record Account(string Name)
     /// Gets the statement balance.
     /// </summary>
     public decimal? StatementBalance { get; init; }
-
-    /// <summary>
-    /// Gets the account type, as a string.
-    /// </summary>
-    public abstract string Type { get; init; }
 
     /// <summary>
     /// Gets the account type.
@@ -81,6 +77,11 @@ public abstract record Account(string Name)
         /// An investment account.
         /// </summary>
         public const string Investment = "Invst";
+
+        /// <summary>
+        /// An investment account.
+        /// </summary>
+        public const string Investment2 = "Port";
 
         /// <summary>
         /// A container for memorized transactions.

--- a/src/Nerdbank.Qif/BankAccount.cs
+++ b/src/Nerdbank.Qif/BankAccount.cs
@@ -10,7 +10,7 @@ namespace Nerdbank.Qif;
 /// </summary>
 /// <param name="Type">The type of the account. Typically one of the values found in the <see cref="Types"/> class. This should <em>not</em> be <see cref="Types.Investment"/> as that should lead to creation of an <see cref="InvestmentAccount"/>.</param>
 /// <param name="Name">The name of the account.</param>
-public record BankAccount(string Type, string Name) : Account(Name)
+public record BankAccount(string Type, string Name) : Account(Type, Name)
 {
     /// <inheritdoc/>
     public override List<BankTransaction> Transactions { get; } = new();

--- a/src/Nerdbank.Qif/InvestmentAccount.cs
+++ b/src/Nerdbank.Qif/InvestmentAccount.cs
@@ -6,27 +6,15 @@ namespace Nerdbank.Qif;
 /// <summary>
 /// An investment account.
 /// </summary>
+/// <param name="Type">The type of the account. This is expected to be <see cref="Account.Types.Investment"/>.</param>
 /// <param name="Name">The name of the account.</param>
-public record InvestmentAccount(string Name) : Account(Name)
+public record InvestmentAccount(string Type, string Name) : Account(Type, Name)
 {
     /// <inheritdoc/>
     public override List<InvestmentTransaction> Transactions { get; } = new();
 
     /// <inheritdoc/>
     public override AccountType? AccountType => Qif.AccountType.Investment;
-
-    /// <inheritdoc/>
-    public override string Type
-    {
-        get => Types.Investment;
-        init
-        {
-            if (value != Types.Investment)
-            {
-                throw new ArgumentException();
-            }
-        }
-    }
 
     /// <inheritdoc/>
     public virtual bool Equals(InvestmentAccount? other)

--- a/src/Nerdbank.Qif/QifSerializer.cs
+++ b/src/Nerdbank.Qif/QifSerializer.cs
@@ -787,8 +787,8 @@ public class QifSerializer
             }
         }
 
-        Account result = type == Account.Types.Investment
-            ? new InvestmentAccount(ValueOrThrow(name, Account.FieldNames.Name))
+        Account result = type is Account.Types.Investment or Account.Types.Investment2
+            ? new InvestmentAccount(type, ValueOrThrow(name, Account.FieldNames.Name))
             : new BankAccount(ValueOrThrow(type, Account.FieldNames.Type), ValueOrThrow(name, Account.FieldNames.Name));
 
         return result with

--- a/test/Nerdbank.Qif.Tests/QifSerializerTests.cs
+++ b/test/Nerdbank.Qif.Tests/QifSerializerTests.cs
@@ -381,6 +381,30 @@ TSome Type
     }
 
     [Fact]
+    public void ReadAccount_InvestmentType()
+    {
+        const string qifSource = @"NMy name
+TInvst
+^
+";
+        Account account = Read(qifSource, this.serializer.ReadAccount);
+        Assert.Equal("Invst", account.Type);
+        Assert.Equal(AccountType.Investment, account.AccountType);
+    }
+
+    [Fact]
+    public void ReadAccount_PortType()
+    {
+        const string qifSource = @"NMy name
+TPort
+^
+";
+        Account account = Read(qifSource, this.serializer.ReadAccount);
+        Assert.Equal("Port", account.Type);
+        Assert.Equal(AccountType.Investment, account.AccountType);
+    }
+
+    [Fact]
     public void ReadAccount_Exhaustive()
     {
         const string qifSource = @"NMy name
@@ -531,6 +555,14 @@ TBank
             "NAccount1\nTBank\n^\n",
             this.serializer.Write);
         this.AssertSerialized(
+            new BankAccount(Account.Types.Investment, "Account1"),
+            "NAccount1\nTInvst\n^\n",
+            this.serializer.Write);
+        this.AssertSerialized(
+            new BankAccount(Account.Types.Investment2, "Account1"),
+            "NAccount1\nTPort\n^\n",
+            this.serializer.Write);
+        this.AssertSerialized(
             new BankAccount("Z", "Account1") { Description = "desc", CreditLimit = 5, StatementBalance = 6, StatementBalanceDate = Date },
             "NAccount1\nTZ\nDdesc\nL5\n/02/03/2013\n$6\n^\n",
             this.serializer.Write);
@@ -561,7 +593,7 @@ TBank
     public void Write_InvestmentAccount_WithTransactions()
     {
         this.AssertSerialized(
-            new InvestmentAccount("Account1")
+            new InvestmentAccount(Account.Types.Investment, "Account1")
             {
                 Transactions =
                 {
@@ -732,7 +764,7 @@ D02/04/2013
                         new BankTransaction(AccountType.CreditCard, Date2, 16),
                     },
                 },
-                new InvestmentAccount("Account2")
+                new InvestmentAccount(Account.Types.Investment, "Account2")
                 {
                     Transactions =
                     {


### PR DESCRIPTION
The latest Quicken version produces investment accounts as `Port`, yet emits transactions for them as type `Invst` under an account heading with type `Invst` as well. Quite strange, actually.
